### PR TITLE
Look for public paths and load index from there if they exist

### DIFF
--- a/bin/kirby
+++ b/bin/kirby
@@ -1,7 +1,19 @@
 #!/usr/bin/env php
 <?php
 
-$index = getcwd() . '/index.php';
+$files = glob(getcwd().'/*/index.php', GLOB_BRACE);
+
+$path = array_map(function ($file) {
+	preg_match_all("#(/www/|/public/|/public_html/)#i", $file, $matches);
+
+	if(!empty($matches))
+	{
+		return $matches;
+	}
+}, $files);
+
+$path = $path[0][0][0] ?? '/';
+$index = getcwd().($path ?? '/').'index.php';
 
 // try to load Kirby’s index.php
 if (file_exists($index) === true) {


### PR DESCRIPTION
As noted in #12 public folder setups have problems working with the CLI because it doesn't look for the correct `index.php`.

This PR should fix this by scanning all the first level folders for an index.php and hold them against the "well known" public html folders (www|public|public_html) and load the `index.php` from there. If none of these exist the `index.php` will be loaded from root.

Tested on default plainkit and plainkit with www/public/public_html setups.

Feel free to let me know if you'd rather see this done in another way. For example just checking the folders with an exist on `index.php` in a for each.

I'd like to get this show on the road se we can start building Kirby CLI plugins 😇 