### PR TITLE
Patch method 'json'

### DIFF
--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -338,9 +338,9 @@ class CLI
 	/**
 	 * Creates pretty json
 	 */
-	public function json(array $data = []): string
+	public function json(array $data = []): CLImate
 	{
-		return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+		return $this->climate->out(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
 	}
 
 	/**


### PR DESCRIPTION
Looking at the `CLImate` docs linked in `README.md`, one would expect that `$cli->json($myJson)` (eg inside a custom command) outputs JSON into the terminal - but all it does is return `json_encode`d data, which then needs to be `out`put to the terminal, like this: `$cli->out($cli->json($myJson))` - which is not desired behaviour from the looks of it.

In order to comply with aforementioned docs, this (monkey)patch solves this problem, although it may be further improved (I guess).

Cheers,
S1SYPHOS