### PR TITLE
Add check for index() expecting to live in vendor/ directory

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -41,7 +41,16 @@ function index(): string|null
 	];
 
 	foreach ($locations as $location) {
+		// Try to find the index.php in current working directory
 		$index = realpath(getcwd() . '/' . $location . '/index.php');
+
+		if ($index !== false) {
+			return $index;
+		}
+
+		// Try to find the index.php from the (possible) root of the project
+		// in the __ROOT__ <- /vendor/getkirby/cli directory
+		$index = realpath(dirname(__DIR__, 3) . '/' . $location . '/index.php');
 
 		if ($index !== false) {
 			return $index;


### PR DESCRIPTION
When you call Kirby CLI via absolute path (e.g.: cron jobs, daemons, etc.), the working directory is set to whatever the running program deems a good idea (often home directory).

Since this is pure composer plugin, we can be be almost 100% sure  that the bootstrap script looking for index() lives in `__ROOT__/vendor/getkirby/cms/bootstrap.php`, and look for the possible index with this expectation.

I haven't added any tests, because I have no idea how to test `__DIR__` calls, but since it's very simple call… manually testing it, it works on my machine 👍🏻😀