### PR TITLE
Use namespaced class names

### DIFF
--- a/commands/make/_templates/model.php
+++ b/commands/make/_templates/model.php
@@ -1,5 +1,5 @@
 <?php
 
-class {{ className }}Page extends Page {
+class {{ className }}Page extends Kirby\Cms\Page {
 
 }


### PR DESCRIPTION
### Fixes

- Use namespaced class names in make:* commands #31