### PR TITLE
Enable host setup loading via ENV variable

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,6 +12,11 @@ function bootstrap(): string|null
 		// avoid any output in the CLI
 		$_ENV['KIRBY_RENDER'] = false;
 
+		if (empty($_ENV['KIRBY_HOST']) === false) {
+			$_SERVER['SERVER_NAME'] = $_ENV['KIRBY_HOST'];
+			$_SERVER['HTTP_HOST']   = $_ENV['KIRBY_HOST'];
+		}
+
 		ob_start();
 		require $index;
 		ob_end_clean();


### PR DESCRIPTION
You can now load a different host config by setting the new KIRBY_HOST env variable: 

```
env KIRBY_HOST=production.com kirby my-command
```

@lukasbestle could you have a look at this. I tried to also implement the idea of an additional --env or --host option, but we need to load Kirby first before we can really start parsing the arguments and it would have turned into a bad hack. 

I found HOST to be better than ENV, but I wonder if we should do KIRBY_CLI_HOST instead? Not entirely sure. 