### PR TITLE
Use getenv() for KIRBY_HOST

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,9 +12,9 @@ function bootstrap(): string|null
 		// avoid any output in the CLI
 		$_ENV['KIRBY_RENDER'] = false;
 
-		if (empty($_ENV['KIRBY_HOST']) === false) {
-			$_SERVER['SERVER_NAME'] = $_ENV['KIRBY_HOST'];
-			$_SERVER['HTTP_HOST']   = $_ENV['KIRBY_HOST'];
+		if ($host = getenv('KIRBY_HOST')) {
+			$_SERVER['SERVER_NAME'] = $host;
+			$_SERVER['HTTP_HOST']   = $host;
 		}
 
 		ob_start();


### PR DESCRIPTION
The contents of `$_ENV` might be empty, even though environment variables are present:
https://stackoverflow.com/questions/3780866/why-is-my-env-empty

For example:
- The `php.ini` can disallow filling the of `$_ENV` 
- Variables could end up in `$_SERVER` instead of `$_ENV`

By using [getenv()](https://www.php.net/manual/en/function.getenv.php) instead of `$_ENV` we can fix some of those issues because it is a bit more liberal when it comes to the detection of environment variables.

