### PR TITLE
Add Kirby license information commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This should print the Kirby CLI version and a list of available commands
 - kirby install
 - kirby install:kit
 - kirby install:repo
+- kirby license:info
+- kirby license:renewal
 - kirby make:blueprint
 - kirby make:collection
 - kirby make:command

--- a/commands/license/info.php
+++ b/commands/license/info.php
@@ -21,6 +21,15 @@ return [
 			'json'
 		];
 
+		$licenseFields = [
+			'activation',
+			'code',
+			'date',
+			'domain',
+			'email',
+			'order',
+		];
+
 		$format = $cli->arg('format');
 		$format = $format ? $format : 'table';
 
@@ -32,6 +41,8 @@ return [
 		$license = $kirby->system()->license();
 
 		$data = $license->content();
+		// Only include the fields we want to display
+		$data = array_intersect_key($data, array_flip($licenseFields));
 		$data['renewal'] = $license->renewal();
 
 		// Print License info as table
@@ -42,6 +53,7 @@ return [
 				$tableData[] = ['Key' => $key, 'Value' => $value ?? '—'];
 			}
 
+			// Use the Climate library to create a table for better readability
 			$cli->climate()->table($tableData);
 		} else {
 			// Print License info as JSON

--- a/commands/license/info.php
+++ b/commands/license/info.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+use Kirby\CLI\CLI;
+
+return [
+	'description' => 'Displays Kirby license information in table or JSON format.',
+	'args' => [
+		'format' => [
+			'description' => 'Output format: table or json.',
+			'prefix' => 'f',
+			'longPrefix' => 'format'
+		]
+	],
+	'command' => static function (CLI $cli): void {
+		$kirby = $cli->kirby();
+
+		$supportedFormats = [
+			'table',
+			'json'
+		];
+
+		$format = $cli->arg('format');
+		$format = $format ? $format : 'table';
+
+		if (!in_array($format, $supportedFormats)) {
+			$cli->error('Invalid format. Supported formats are: ' . implode(', ', $supportedFormats));
+			return;
+		}
+
+		$license = $kirby->system()->license();
+
+		$data = $license->content();
+		$data['renewal'] = $license->renewal();
+
+		// Print License info as table
+		if ($format === 'table') {
+			$cli->success('Kirby License Information:');
+			$tableData = [];
+			foreach ($data as $key => $value) {
+				$tableData[] = ['Key' => $key, 'Value' => $value ?? '—'];
+			}
+
+			$cli->climate()->table($tableData);
+		} else {
+			// Print License info as JSON
+			$cli->climate()->json($data);
+		}
+	}
+];

--- a/commands/license/info.php
+++ b/commands/license/info.php
@@ -43,7 +43,7 @@ return [
 		$data = $license->content();
 		// Only include the fields we want to display
 		$data = array_intersect_key($data, array_flip($licenseFields));
-		$data['renewal'] = $license->renewal(format: 'Y-m-d', handler: 'date');
+		$data['renewal'] = $license->renewal(format: 'Y-m-d H:i:s', handler: 'date');
 
 		// Print License info as table
 		if ($format === 'table') {

--- a/commands/license/info.php
+++ b/commands/license/info.php
@@ -43,7 +43,7 @@ return [
 		$data = $license->content();
 		// Only include the fields we want to display
 		$data = array_intersect_key($data, array_flip($licenseFields));
-		$data['renewal'] = $license->renewal();
+		$data['renewal'] = $license->renewal(format: 'Y-m-d', handler: 'date');
 
 		// Print License info as table
 		if ($format === 'table') {

--- a/commands/license/renewal.php
+++ b/commands/license/renewal.php
@@ -10,7 +10,7 @@ return [
 		'format' => [
 			'prefix'       => 'f',
 			'longPrefix'   => 'format',
-			'description'  => 'The format for the renewal date or "timestamp"',
+			'description'  => 'The format for the renewal date (any format supported by PHP\'s `date()` function) or "timestamp"',
 			'defaultValue' => 'Y-m-d'
 		]
 	],
@@ -24,7 +24,10 @@ return [
 			$format = null;
 		}
 
-		$renewal = $license->renewal($format);
+		$renewal = $license->renewal(
+			format: $format,
+			handler: 'date'
+		);
 
 		if ($renewal === null) {
 			$cli->error('No Kirby License is activated.');

--- a/commands/license/renewal.php
+++ b/commands/license/renewal.php
@@ -6,12 +6,25 @@ use Kirby\CLI\CLI;
 
 return [
 	'description' => 'Show the renewal date of the activated Kirby license.',
+	'args' => [
+		'format' => [
+			'prefix'       => 'f',
+			'longPrefix'   => 'format',
+			'description'  => 'The format for the renewal date or "timestamp"',
+			'defaultValue' => 'Y-m-d'
+		]
+	],
 	'command' => static function (CLI $cli): void {
 		$kirby = $cli->kirby();
 
 		$license = $kirby->system()->license();
+		$format  = $cli->arg('format');
 
-		$renewal = $license->renewal();
+		if (strtolower($format) === 'timestamp') {
+			$format = null;
+		}
+
+		$renewal = $license->renewal($format);
 
 		if ($renewal === null) {
 			$cli->error('No Kirby License is activated.');

--- a/commands/license/renewal.php
+++ b/commands/license/renewal.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types = 1);
+
+use Kirby\CLI\CLI;
+
+return [
+	'description' => 'Show the renewal date of the activated Kirby license.',
+	'command' => static function (CLI $cli): void {
+		$kirby = $cli->kirby();
+
+		$license = $kirby->system()->license();
+
+		$renewal = $license->renewal();
+
+		if ($renewal === null) {
+			$cli->error('No Kirby License is activated.');
+			return;
+		}
+
+		$cli->success($renewal);
+	}
+];


### PR DESCRIPTION
## Description
This PR adds two new commands under the license namespace:
- `license:info`: Displays Kirby license details in a table or as JSON
- `license:renewal`: Shows the renewal date for the current license

### Reasoning
The `license:info` command, with the --format=json option, can be used within a CI system to programatically keep on track of Kirby license status when managing multiple Kirby installations. 

`license:renewal` provides a shortcut to get the license renewal date. 

### Additional context
The commands rely on `kirby()->system()->license()` method, which was added in 4.0.0. Currently the commands do not check the Kirby version and will throw an error if used on an older Kirby installation.

This can be addressed but i could not find any exemplary code regarding on how to deal with backwards compatability.
