### PR TITLE
feat: Accept class names for commands

### DIFF
--- a/commands/migrate/to/public-folder.php
+++ b/commands/migrate/to/public-folder.php
@@ -1,10 +1,3 @@
 <?php
 
-declare(strict_types = 1);
-
-use Kirby\CLI\Commands\Migrate\To\PublicFolder;
-
-return [
-	'description' => 'Switch to a public folder setup',
-	'command'     => PublicFolder::command(...)
-];
+return Kirby\CLI\Commands\Migrate\To\PublicFolder::class;

--- a/commands/migrate/to/root-folder.php
+++ b/commands/migrate/to/root-folder.php
@@ -1,10 +1,3 @@
 <?php
 
-declare(strict_types = 1);
-
-use Kirby\CLI\Commands\Migrate\To\RootFolder;
-
-return [
-	'description' => 'Switch to a root folder setup',
-	'command'     => RootFolder::command(...)
-];
+return Kirby\CLI\Commands\Migrate\To\RootFolder::class;

--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -251,6 +251,30 @@ class CLI
 	}
 
 	/**
+	 * Creates a command array from a classname
+	 */
+	protected function createClassCommand(string $className): array
+	{
+		if (class_exists($className) === false) {
+			throw new Exception("Command class {$className} does not exist");
+		}
+
+		// Check if the class extends the abstract Command class
+		if (is_subclass_of($className, Command::class) === false) {
+			throw new Exception("Command class {$className} must extend " . Command::class);
+		}
+
+		// Build command array with optional description and args
+		$command = [
+			'args'        => $className::args(),
+			'command'     => $className::command(...),
+			'description' => $className::description(),
+		];
+
+		return $command;
+	}
+
+	/**
 	 * Creates default values for command roots
 	 * if they are not set
 	 */
@@ -388,6 +412,11 @@ class CLI
 			if (empty($command) === true) {
 				throw $e;
 			}
+		}
+
+		// if it's a simple classname string, convert to command array
+		if (is_string($command) === true) {
+			$command = $this->createClassCommand($command);
 		}
 
 		// validate the command format

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Kirby\CLI;
+
+/**
+ * Abstract base class for CLI commands
+ *
+ * @package   Kirby CLI
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+abstract class Command
+{
+	/**
+	 * Optional command arguments
+	 * Override this method in your command class to define arguments
+	 * @return array<string, mixed>
+	 */
+	public static function args(): array
+	{
+		return [];
+	}
+
+	/**
+	 * The main command execution method
+	 * Must be implemented by all command classes
+	 */
+	abstract public static function command(CLI $cli): void;
+
+	/**
+	 * Optional command description
+	 * Override this method in your command class to provide a description
+	 */
+	public static function description(): string|null
+	{
+		return null;
+	}
+}

--- a/src/CLI/Commands/Migrate/To/PublicFolder.php
+++ b/src/CLI/Commands/Migrate/To/PublicFolder.php
@@ -5,11 +5,17 @@ declare(strict_types = 1);
 namespace Kirby\CLI\Commands\Migrate\To;
 
 use Kirby\CLI\CLI;
+use Kirby\CLI\Command;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 
-class PublicFolder
+class PublicFolder extends Command
 {
+	public static function description(): string
+	{
+		return 'Switch to a public folder setup';
+	}
+
 	public static function command(CLI $cli): void
 	{
 		$dir = $cli->dir();

--- a/src/CLI/Commands/Migrate/To/RootFolder.php
+++ b/src/CLI/Commands/Migrate/To/RootFolder.php
@@ -10,6 +10,11 @@ use Kirby\Filesystem\F;
 
 class RootFolder extends PublicFolder
 {
+	public static function description(): string
+	{
+		return 'Switch to a root folder setup';
+	}
+
 	public static function command(CLI $cli): void
 	{
 		$dir = $cli->dir();

--- a/src/CLI/Commands/UUID/Duplicates.php
+++ b/src/CLI/Commands/UUID/Duplicates.php
@@ -5,11 +5,27 @@ declare(strict_types = 1);
 namespace Kirby\CLI\Commands\UUID;
 
 use Kirby\CLI\CLI;
+use Kirby\CLI\Command;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Uuid\Uuid;
 
-class Duplicates
+class Duplicates extends Command
 {
+	public static function description(): string
+	{
+		return 'Find and optionally fix duplicate UUIDs';
+	}
+
+	public static function args(): array
+	{
+		return [
+			'fix' => [
+				'description' => 'Fix duplicate UUIDs by generating new ones',
+				'noValue'     => true,
+			],
+		];
+	}
+
 	protected static function check(CLI $cli, ModelWithContent $model, array &$uuids, array &$duplicates): void
 	{
 		$uuid = $model->content()->get('uuid');


### PR DESCRIPTION
## Changelog

### Features

The CLI now accepts class names as commands. The command classes must extend the `Kirby\CLI\Command` abstract and define a static command method. 

```php
// in a plugin

use Kirby\CLI\CLI;
use Kirby\CLI\Command;

class HelloWorld extends Command
{
  public static function args(): array
  {
    return [ // optional args ];
  }

  public static function command(CLI $cli): void
  {
    $cli->out('Hello world');
  }

  public static function description(): string|null
  {
    return 'The infamous hello world example';
  }
}

Kirby::plugin('me/mycommands', [
  'commands' => [
    'helloworld' => HelloWorld::class
  ]
]);
```