### PR TITLE
fix: Update composer.json start script target folder during migrations

### DIFF
--- a/src/CLI/Commands/Migrate/To/PublicFolder.php
+++ b/src/CLI/Commands/Migrate/To/PublicFolder.php
@@ -31,6 +31,7 @@ class PublicFolder
 
 		static::makeIndexPHP($cli, $publicDir);
 		static::removeOldIndexPHP($cli);
+		static::updateComposerConfig($cli);
 
 		$cli->br();
 		$cli->success('Migrated to a public folder setup');
@@ -41,6 +42,29 @@ class PublicFolder
 		$cli->br();
 		$cli->confirmToContinue("💡 Migrating your folder setup can lead to a broken site.\n\nMake sure to backup your current installation. If you have modified your index.php you might need to adjust the new index.php after the migration.\n\nDo you want to continue?");
 		$cli->br();
+	}
+
+	protected static function updateComposerConfig(CLI $cli): void
+	{
+		$file = $cli->dir() . '/composer.json';
+
+		if (is_file($file) === false) {
+			return;
+		}
+
+		$composer = json_decode(F::read($file), true);
+		$start    = $composer['scripts']['start'] ?? null;
+
+		if (is_array($start) === true) {
+			foreach ($start as $key => $command) {
+				if (str_contains($command, '-S localhost:8000') === true && str_contains($command, '-t public') === false) {
+					$composer['scripts']['start'][$key] = str_replace('-S localhost:8000', '-S localhost:8000 -t public', $command);
+				}
+			}
+
+			F::write($file, $cli->json($composer));
+			$cli->out('✅ The composer.json has been updated');
+		}
 	}
 
 	protected static function makeIndexPHP(CLI $cli, string $publicDir)

--- a/src/CLI/Commands/Migrate/To/RootFolder.php
+++ b/src/CLI/Commands/Migrate/To/RootFolder.php
@@ -37,9 +37,33 @@ class RootFolder extends PublicFolder
 
 		static::makeIndexPHP($cli, $dir);
 		static::removePublicDir($cli, $publicDir);
+		static::updateComposerConfig($cli);
 
 		$cli->br();
 		$cli->success('Migrated to a root folder setup');
+	}
+
+	protected static function updateComposerConfig(CLI $cli): void
+	{
+		$file = $cli->dir() . '/composer.json';
+
+		if (is_file($file) === false) {
+			return;
+		}
+
+		$composer = json_decode(F::read($file), true);
+		$start    = $composer['scripts']['start'] ?? null;
+
+		if (is_array($start) === true) {
+			foreach ($start as $key => $command) {
+				if (str_contains($command, '-S localhost:8000 -t public') === true) {
+					$composer['scripts']['start'][$key] = str_replace('-S localhost:8000 -t public', '-S localhost:8000', $command);
+				}
+			}
+
+			F::write($file, $cli->json($composer));
+			$cli->out('✅ The composer.json has been updated');
+		}
 	}
 
 	protected static function makeIndexPHP(CLI $cli, string $dir)


### PR DESCRIPTION
## Description

This PR fixes an issue where the `migrate:to:public-folder` and `migrate:to:root-folder` commands didn't update the `composer.json` start script's target folder configuration for the PHP built-in development server.

## Problem

When migrating between folder setups:
- **Public folder migration**: The `composer.json` start script wasn't updated to include `-t public` flag, causing the development server to serve from the wrong directory
- **Root folder migration**: The `composer.json` start script wasn't updated to remove the `-t public` flag, causing the development server to fail or serve from the wrong directory

## Solution

Added `updateComposerConfig()` method to both migration classes that:
- Detects PHP built-in server commands in `composer.json` scripts.start
- Updates the target folder flag (`-t public`) appropriately based on the migration direction
- Only modifies commands matching the standard `localhost:8000` pattern

## Changes

- Added `updateComposerConfig()` method to `PublicFolder` class
- Added `updateComposerConfig()` override to `RootFolder` class  
- Both methods are called during their respective migration processes
- Updates are only made when `composer.json` exists and contains matching start scripts

## Testing

- [x] Verified the code follows existing codebase patterns
- [x] Confirmed error handling is consistent with other commands
- [x] Tested logic handles edge cases appropriately for development tool usage

## Related

Fixes the issue where `composer start` wouldn't work correctly after running migration commands.