### PR TITLE
ci: enforce release branch workflow and auto-bump version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,34 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate & bump
+        run: |
+          VERSION="${GITHUB_REF_NAME#release/}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Branch name must be release/X.Y.Z (got '$GITHUB_REF_NAME')"
+            exit 1
+          fi
+          CURRENT=$(composer config version 2>/dev/null || echo "")
+          if [ "$CURRENT" != "$VERSION" ]; then
+            composer config version "$VERSION"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add composer.json
+            git commit -m "chore: bump composer.json to $VERSION"
+            git push origin "${GITHUB_REF_NAME}"
+          fi

--- a/.github/workflows/enforce-branch.yml
+++ b/.github/workflows/enforce-branch.yml
@@ -1,0 +1,18 @@
+name: Enforce branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch
+        run: |
+          if [[ ! "$GITHUB_HEAD_REF" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::PRs to main must come from a release/X.Y.Z branch (got '$GITHUB_HEAD_REF')"
+            exit 1
+          fi
+          echo "OK: source branch '$GITHUB_HEAD_REF' is a valid release branch"


### PR DESCRIPTION
## Description

Add two GitHub Actions workflows:

- bump-version: on push to release/X.Y.Z, validate the branch name and sync composer.json version to match, committing the bump automatically.
- enforce-branch: require PRs targeting main to originate from a release/X.Y.Z branch.


